### PR TITLE
fix cache builds

### DIFF
--- a/circle/docker-image-test.sh
+++ b/circle/docker-image-test.sh
@@ -1,0 +1,49 @@
+#!/bin/bash -e
+
+# Copyright 2017 Bitnami
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+DOCKERFILE=${DOCKERFILE:-Dockerfile}
+
+log() {
+  echo -e "$(date "+%T.%2N") ${@}"
+}
+
+info() {
+  log "INFO  ==> ${@}"
+}
+
+warn() {
+  log "WARN  ==> ${@}"
+}
+
+error() {
+  log "ERROR ==> ${@}"
+}
+
+docker_build() {
+  info "Building '${1}' image..."
+  local IMAGE_BUILD_TAG=${1}
+  local IMAGE_BUILD_DIR=${2:-.}
+  docker build --rm=false -f $IMAGE_BUILD_DIR/$DOCKERFILE -t $IMAGE_BUILD_TAG $IMAGE_BUILD_DIR
+}
+
+if [[ -n $RELEASE_SERIES_LIST ]]; then
+  IFS=',' read -ra RELEASE_SERIES_ARRAY <<< "$RELEASE_SERIES_LIST"
+  for RS in "${RELEASE_SERIES_ARRAY[@]}"; do
+    docker_build $DOCKER_PROJECT/$IMAGE_NAME:$RS-$CIRCLE_BUILD_NUM $RS || exit 1
+  done
+else
+  docker_build $DOCKER_PROJECT/$IMAGE_NAME:$CIRCLE_BUILD_NUM . || exit 1
+fi

--- a/circle/docker-pull-cache.sh
+++ b/circle/docker-pull-cache.sh
@@ -1,0 +1,42 @@
+#!/bin/bash -e
+
+# Copyright 2017 Bitnami
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+DOCKERFILE=${DOCKERFILE:-Dockerfile}
+
+log() {
+  echo -e "$(date "+%T.%2N") ${@}"
+}
+
+info() {
+  log "INFO  ==> ${@}"
+}
+
+warn() {
+  log "WARN  ==> ${@}"
+}
+
+error() {
+  log "ERROR ==> ${@}"
+}
+
+if [[ -n $RELEASE_SERIES_LIST ]]; then
+  IFS=',' read -ra RELEASE_SERIES_ARRAY <<< "$RELEASE_SERIES_LIST"
+  for RS in "${RELEASE_SERIES_ARRAY[@]}"; do
+    docker pull $DOCKER_PROJECT/$IMAGE_NAME:$RS-buildcache || true
+  done
+else
+  docker pull $DOCKER_PROJECT/$IMAGE_NAME:_ || true
+fi

--- a/circle/docker-release-image.sh
+++ b/circle/docker-release-image.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-# Copyright 2016 Bitnami
+# Copyright 2016 - 2017 Bitnami
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -249,16 +249,15 @@ chart_update_version() {
 }
 
 if [[ -n $DOCKER_PASS ]]; then
-  docker_login                                                  || exit 1
+  docker_login || exit 1
   for TAG in "${TAGS_TO_UPDATE[@]}"; do
     docker_build_and_push $DOCKER_PROJECT/$IMAGE_NAME:$TAG $RELEASE_SERIES || exit 1
   done
 fi
 
 if [[ -n $GCLOUD_SERVICE_KEY ]]; then
+  gcloud_login || exit 1
   echo 'ENV BITNAMI_CONTAINER_ORIGIN=GCR' >> Dockerfile
-
-  gcloud_login                                                                || exit 1
   for TAG in "${TAGS_TO_UPDATE[@]}"; do
     docker_build_and_gcloud_push gcr.io/$GCLOUD_PROJECT/$IMAGE_NAME:$TAG $RELEASE_SERIES || exit 1
   done
@@ -324,7 +323,7 @@ if [[ -n $CHART_NAME && -n $DOCKER_PASS ]]; then
         fi
       fi
     else
-      warn "Chart release skipped!"
+      warn "Chart release/updates skipped!"
     fi
   else
     info "Chart '$CHART_NAME' could not be found in '$CHART_REPO' repo"

--- a/circle/docker-release-image.sh
+++ b/circle/docker-release-image.sh
@@ -50,6 +50,7 @@ for RS in "${RELEASE_SERIES_ARRAY[@]}"; do
     RELEASE_SERIES=$RS
     let MATCHING_RS_FOUND+=1
     TAGS_TO_UPDATE+=($RELEASE_SERIES)
+    TAGS_TO_UPDATE+=($RELEASE_SERIES-buildcache)
   fi
 done
 
@@ -59,8 +60,13 @@ if [[ $MATCHING_RS_FOUND > 1 ]]; then
   exit 1
 fi
 
-if [[ $RELEASE_SERIES == $LATEST_STABLE ]]; then
+if [[ -n $RELEASE_SERIES ]]; then
+  if [[ $RELEASE_SERIES == $LATEST_STABLE ]]; then
+    TAGS_TO_UPDATE+=('latest')
+  fi
+else
   TAGS_TO_UPDATE+=('latest')
+  TAGS_TO_UPDATE+=('_')
 fi
 
 DOCKERFILE=${DOCKERFILE:-Dockerfile}
@@ -244,7 +250,6 @@ chart_update_version() {
 
 if [[ -n $DOCKER_PASS ]]; then
   docker_login                                                  || exit 1
-  docker_build_and_push $DOCKER_PROJECT/$IMAGE_NAME:_           || exit 1
   for TAG in "${TAGS_TO_UPDATE[@]}"; do
     docker_build_and_push $DOCKER_PROJECT/$IMAGE_NAME:$TAG $RELEASE_SERIES || exit 1
   done

--- a/circle/docker-update-cache.sh
+++ b/circle/docker-update-cache.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-# Copyright 2016 Bitnami
+# Copyright 2016 - 2017 Bitnami
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -54,8 +54,7 @@ docker_build_and_push() {
 }
 
 if [[ -n $DOCKER_PASS ]]; then
-  docker_login                                || exit 1
-  # RELEASE_SERIES_LIST will be an array of comma separated release series
+  docker_login || exit 1
   if [[ -n $RELEASE_SERIES_LIST ]]; then
     IFS=',' read -ra RELEASE_SERIES_ARRAY <<< "$RELEASE_SERIES_LIST"
     for RS in "${RELEASE_SERIES_ARRAY[@]}"; do

--- a/circle/docker-update-cache.sh
+++ b/circle/docker-update-cache.sh
@@ -39,7 +39,9 @@ docker_login() {
 
 docker_build() {
   info "Building '${1}' image..."
-  docker build --rm=false -f $DOCKERFILE -t ${1} ${2}
+  local IMAGE_BUILD_TAG=${1}
+  local IMAGE_BUILD_DIR=${2:-.}
+  docker build --rm=false -f $IMAGE_BUILD_DIR/$DOCKERFILE -t $IMAGE_BUILD_TAG $IMAGE_BUILD_DIR
 }
 
 docker_push() {
@@ -57,9 +59,9 @@ if [[ -n $DOCKER_PASS ]]; then
   if [[ -n $RELEASE_SERIES_LIST ]]; then
     IFS=',' read -ra RELEASE_SERIES_ARRAY <<< "$RELEASE_SERIES_LIST"
     for RS in "${RELEASE_SERIES_ARRAY[@]}"; do
-      docker_build_and_push $DOCKER_PROJECT/$IMAGE_NAME:_ $RS || exit 1
+      docker_build_and_push $DOCKER_PROJECT/$IMAGE_NAME:$RS-buildcache $RS || exit 1
     done
   else
-    docker_build_and_push $DOCKER_PROJECT/$IMAGE_NAME:_ "." || exit 1
+    docker_build_and_push $DOCKER_PROJECT/$IMAGE_NAME:_ . || exit 1
   fi
 fi


### PR DESCRIPTION
changes:
 - specify the docker build context in `docker_build` arguments
 - fixes building of build cache
 - adds `docker-pull-cache.sh` script
 - adds `docker-image-test.sh` script

sample `circle.yml` spec updates:

```diff
diff --git a/circle.yml b/circle.yml
index 9c04a7f..688f712 100644
--- a/circle.yml
+++ b/circle.yml
@@ -2,6 +2,9 @@ machine:
   services:
   - docker
   environment:
+    RELEASE_SERIES_LIST: 3.3
+    LATEST_STABLE: 3.3
+    DOCKERFILE: Dockerfile
     IMAGE_NAME: redmine
     CHART_NAME: redmine
     CHART_REPO: https://github.com/kubernetes/charts
@@ -12,11 +15,11 @@ dependencies:
   override:
   - docker info
   - gcloud version
-  - docker pull $DOCKER_PROJECT/$IMAGE_NAME:_ || true
+  - curl -sL https://raw.githubusercontent.com/bitnami/test-infra/master/circle/docker-pull-cache.sh | bash -
 
 test:
   override:
-  - docker build --rm=false -t $DOCKER_PROJECT/$IMAGE_NAME:$CIRCLE_BUILD_NUM .
+  - curl -sL https://raw.githubusercontent.com/bitnami/test-infra/master/circle/docker-image-test.sh | bash -
 
 deployment:
   cache:
```

Validation:
 - https://circleci.com/gh/damagehead/bitnami-docker-drupal/15 (single release)
 - https://circleci.com/gh/damagehead/bitnami-docker-redmine/230 (multi release, latest)
 - https://circleci.com/gh/damagehead/bitnami-docker-redmine/231 (multi release)

Docker Hub Tags:
 - https://hub.docker.com/r/experimental/drupal/tags/
 - https://hub.docker.com/r/experimental/redmine/tags/

Chart Updates:
 - https://github.com/damagehead/charts/pulls